### PR TITLE
docs: document admin-password command and update seed workflow

### DIFF
--- a/en/operator-manual/configuration/cli.mdx
+++ b/en/operator-manual/configuration/cli.mdx
@@ -3,6 +3,13 @@ title: "Zylon CLI"
 description: "All the commands available in the CLI"
 ---
 
+## admin-password
+Get a one-time login password for the admin user
+
+Usage: `sudo zylon-cli admin-password`
+
+Calls the backend to generate a temporary password for `admin@zylon.ai` and prints it to stdout. Use this after running `seed` to obtain the initial admin login password.
+
 ## backup
 Create a backup
 
@@ -182,9 +189,10 @@ Usage: `sudo zylon-cli seed --help`
 
 **Flags:**
 
-- `-p, --admin-password`: Root admin password
 - `-e, --email-regex`: All emails matching this regex will be allowed to join the organization. Usually this would be .*@\.yourdomain\.com
 - `-o, --org-name`: Organization name
+
+After seeding, run `sudo zylon-cli admin-password` to retrieve the one-time login password for `admin@zylon.ai`.
 
 ## self-update
 Update the CLI

--- a/en/operator-manual/installation/legacy.mdx
+++ b/en/operator-manual/installation/legacy.mdx
@@ -217,13 +217,10 @@ To start using Zylon you will need to create your organization in it, as well as
 You will need:
 
 - A name for your organization (can be changed later)
-- A password for the root administrator (can be changed later).
-  - Due to some encoding limitations in the CLI some special symbols in password don’t work correctly, prefer using a long alphanumeric password.
 - An email regex to allow users to join automatically. If your usual work email is [`name@company.com`](mailto:name@company.com) your email regex should be `.*@company\.com` . If your access control is performed with SSO (like Microsoft Entra, or Google), you can use `.*`  as your regular expression.
 
 ```bash
-# Put a secure password!
-sudo zylon-cli seed --org-name "My Org" --admin-password "admin" --email-regex ".*@yourcompany\.com"
+sudo zylon-cli seed --org-name "My Org" --email-regex ".*@yourcompany\.com"
 
 # At seed time, if Zylon is not ready,
 # this command will wait until it’s completed.
@@ -233,11 +230,17 @@ sudo zylon-cli seed --org-name "My Org" --admin-password "admin" --email-regex "
   **Running the seed command will WIPE ALL DATA. Only do this once during the Zylon lifecycle**
 </Danger>
 
+After seeding, retrieve the one-time login password for the admin account:
+
+```bash
+sudo zylon-cli admin-password
+```
+
 The credentials to login to Zylon will be:
 
 ```bash
 user: admin@zylon.ai
-password: the_password_you_set_up_previously
+password: the_one_time_password_printed_above
 ```
 
 The root admin email is fixed and will always be `admin@zylon.ai` . You will need to use these credentials to login for the first time in the workspace.

--- a/es/operator-manual/configuration/cli.mdx
+++ b/es/operator-manual/configuration/cli.mdx
@@ -3,6 +3,13 @@ title: "CLI de Zylon"
 description: "Todos los comandos disponibles en la CLI"
 ---
 
+## admin-password
+Obtener una contraseña de un solo uso para el usuario administrador
+
+Uso: `sudo zylon-cli admin-password`
+
+Llama al backend para generar una contraseña temporal para `admin@zylon.ai` y la imprime en stdout. Úsalo después de ejecutar `seed` para obtener la contraseña de inicio de sesión inicial del administrador.
+
 ## backup
 Crear una copia de seguridad
 
@@ -182,9 +189,10 @@ Uso: `sudo zylon-cli seed --help`
 
 **Banderas:**
 
-- `-p, --admin-password`: Contraseña del administrador raíz
 - `-e, --email-regex`: Todos los correos electrónicos que coincidan con esta expresión regular podrán unirse a la organización. Normalmente esto sería .*@\.sudominio\.com
 - `-o, --org-name`: Nombre de la organización
+
+Después de hacer el seed, ejecuta `sudo zylon-cli admin-password` para obtener la contraseña de un solo uso para `admin@zylon.ai`.
 
 ## self-update
 Actualizar la CLI

--- a/es/operator-manual/installation/legacy.mdx
+++ b/es/operator-manual/installation/legacy.mdx
@@ -217,13 +217,10 @@ Para comenzar a usar Zylon necesitarás crear tu organización en él, así como
 Necesitarás:
 
 - Un nombre para tu organización (puede cambiarse más tarde)
-- Una contraseña para el administrador raíz (puede cambiarse más tarde).
-  - Debido a algunas limitaciones de codificación en la CLI, algunos símbolos especiales en la contraseña no funcionan correctamente, prefiere usar una contraseña alfanumérica larga.
 - Una expresión regular de correo electrónico para permitir que los usuarios se unan automáticamente. Si tu correo electrónico de trabajo habitual es [`name@company.com`](mailto:name@company.com), tu expresión regular de correo electrónico debe ser `.*@company\.com`. Si tu control de acceso se realiza con SSO (como Microsoft Entra, o Google), puedes usar `.*` como tu expresión regular.
 
 ```bash
-# ¡Pon una contraseña segura!
-sudo zylon-cli seed --org-name "Mi Org" --admin-password "admin" --email-regex ".*@yourcompany\.com"
+sudo zylon-cli seed --org-name "Mi Org" --email-regex ".*@yourcompany\.com"
 
 # En el momento de seed, si Zylon no está listo,
 # este comando esperará hasta que se complete.
@@ -233,11 +230,17 @@ sudo zylon-cli seed --org-name "Mi Org" --admin-password "admin" --email-regex "
   **Ejecutar el comando seed BORRARÁ TODOS LOS DATOS. Solo haz esto una vez durante el ciclo de vida de Zylon**
 </Danger>
 
+Después de hacer el seed, obtén la contraseña de un solo uso para la cuenta de administrador:
+
+```bash
+sudo zylon-cli admin-password
+```
+
 Las credenciales para iniciar sesión en Zylon serán:
 
 ```bash
 user: admin@zylon.ai
-password: la_contraseña_que_configuraste_anteriormente
+password: la_contraseña_de_un_solo_uso_impresa_arriba
 ```
 
 El correo electrónico del administrador raíz está fijo y siempre será `admin@zylon.ai`. Necesitarás usar estas credenciales para iniciar sesión por primera vez en el espacio de trabajo.

--- a/snippets/en/installation/installation-seed.mdx
+++ b/snippets/en/installation/installation-seed.mdx
@@ -5,8 +5,6 @@ After Zylon is installed and running, create your organization and root administ
 You'll need:
 
 - **Organization name**: Your company or team name (can be changed later)
-- **Admin password**: Secure password for root administrator (can be changed later)
-  - Use alphanumeric characters due to encoding limitations with special symbols
 - **Email regex**: Pattern to auto-allow users to join
   - For `name@company.com` emails, use: `.*@company\.com`
   - For SSO (Microsoft Entra, Google), you can use: `.*`
@@ -16,7 +14,6 @@ You'll need:
 ```bash
 sudo zylon-cli seed \
   --org-name "My Organization" \
-  --admin-password "secure-password" \
   --email-regex ".*@yourcompany\.com"
 ```
 
@@ -28,11 +25,17 @@ The command will wait if Zylon is not fully ready.
 
 **Login Credentials**
 
-After seeding, use these credentials to log in:
+After seeding, retrieve the one-time login password for the admin account:
+
+```bash
+sudo zylon-cli admin-password
+```
+
+Then log in with:
 
 ```
 Username: admin@zylon.ai
-Password: [the password you set]
+Password: [the one-time password printed above]
 ```
 
 The root admin email is always `admin@zylon.ai` and cannot be changed.

--- a/snippets/es/installation/installation-seed.mdx
+++ b/snippets/es/installation/installation-seed.mdx
@@ -5,8 +5,6 @@ Después de que Zylon esté instalado y en funcionamiento, crea tu organización
 Necesitarás:
 
 - **Nombre de organización**: El nombre de tu empresa o equipo (se puede cambiar más tarde)
-- **Contraseña de administrador**: Contraseña segura para el administrador root (se puede cambiar más tarde)
-  - Usa caracteres alfanuméricos debido a limitaciones de codificación con símbolos especiales
 - **Regex de correo electrónico**: Patrón para permitir automáticamente que los usuarios se unan
   - Para correos `name@company.com`, usa: `.*@company\.com`
   - Para SSO (Microsoft Entra, Google), puedes usar: `.*`
@@ -16,7 +14,6 @@ Necesitarás:
 ```bash
 sudo zylon-cli seed \
   --org-name "Mi Organización" \
-  --admin-password "contraseña-segura" \
   --email-regex ".*@tuempresa\.com"
 ```
 
@@ -28,11 +25,17 @@ El comando esperará si Zylon no está completamente listo.
 
 **Credenciales de Inicio de Sesión**
 
-Después de hacer el seed, usa estas credenciales para iniciar sesión:
+Después de hacer el seed, obtén la contraseña de un solo uso para la cuenta de administrador:
+
+```bash
+sudo zylon-cli admin-password
+```
+
+Luego inicia sesión con:
 
 ```
 Usuario: admin@zylon.ai
-Contraseña: [la contraseña que estableciste]
+Contraseña: [la contraseña de un solo uso impresa arriba]
 ```
 
 El correo electrónico del administrador root siempre es `admin@zylon.ai` y no se puede cambiar.


### PR DESCRIPTION
Remove --admin-password flag from seed, add new admin-password command docs, and update all seed instructions (EN + ES) to use the new one-time password flow via `sudo zylon-cli admin-password`.